### PR TITLE
Refactor Blackjack sheet views for improved SwiftUI adherence

### DIFF
--- a/Blackjack/Views/GameView/Sheets.swift
+++ b/Blackjack/Views/GameView/Sheets.swift
@@ -26,8 +26,8 @@ struct LostSheet: View {
                 // Title indicating game over
                 Text("Game Over!")
                     .font(.system(size: 36, weight: .heavy))
-                    .foregroundStyle(.white)
-                    .shadow(color: .blue.opacity(0.3), radius: 4)
+                    .foregroundStyle(Color.primary) // Changed to .primary
+                    // Removed shadow: .shadow(color: .blue.opacity(0.3), radius: 4)
                     .scaleEffect(isAppearing ? 1 : 0.5)
                     .opacity(isAppearing ? 1 : 0)
 
@@ -36,23 +36,17 @@ struct LostSheet: View {
                     VStack(spacing: 8) {
                         Text("Highest Balance")
                             .font(.headline)
-                            .foregroundStyle(.gray)
+                            .foregroundStyle(Color.secondary) // Changed to .secondary
 
                         Text("$\(highestBalance)")
                             .font(.system(size: 48, weight: .bold))
-                            .foregroundStyle(.blue)
-                            .shadow(color: .blue.opacity(0.3), radius: 8)
+                            .foregroundStyle(Color.accentColor) // Changed to .accentColor
+                        // Removed shadow: .shadow(color: .blue.opacity(0.3), radius: 8)
                     }
                     .padding(.vertical, 24)
                     .padding(.horizontal, 32)
-                    .background(
-                        RoundedRectangle(cornerRadius: 20)
-                            .fill(Color(uiColor: .systemGray6).opacity(0.1))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .stroke(.white.opacity(0.1), lineWidth: 1)
-                            )
-                    )
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20)) // Changed background
+                    // Removed overlay
                 }
                 .scaleEffect(isAppearing ? 1 : 0.8)
                 .opacity(isAppearing ? 1 : 0)
@@ -61,7 +55,7 @@ struct LostSheet: View {
                 Text("Your balance is $0. You've been refilled. Press continue to keep playing.")
                     .font(.subheadline)
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(.gray)
+                    .foregroundStyle(Color.secondary) // Changed to .secondary
                     .padding(.horizontal, 24)
 
                 // Button to continue the game
@@ -77,7 +71,7 @@ struct LostSheet: View {
             }
             .padding(.vertical, 32)
         }
-        .presentationDetents([.height(500)])
+        .presentationDetents([.fraction(0.65)]) // Changed from .height(500)
         .onAppear {
             // Animate the appearance of the sheet
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
@@ -109,7 +103,7 @@ struct PotSheet: View {
                 // Title for the bet placement screen
                 Text("Place Your Bet")
                     .font(.system(size: 32, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.primary) // Changed to .primary
                     .opacity(isAppearing ? 1 : 0)
                     .offset(y: isAppearing ? 0 : 20)
 
@@ -118,16 +112,10 @@ struct PotSheet: View {
                     VStack(spacing: 24) {
                         // Chip stack view displaying the current bet amount
                         chipStack(amount: Int(potSliderValue))
-                            .font(.system(size: 36, weight: .bold))
+                            .font(.system(size: 36, weight: .bold)) // Note: .font modifier on chipStack directly might not be standard. If chipStack has its own internal font settings, this might be redundant or conflicting.
                             .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .fill(Color(uiColor: .systemGray6).opacity(0.1))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 20)
-                                            .stroke(.white.opacity(0.1), lineWidth: 1)
-                                    )
-                            )
+                            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20)) // Changed background
+                            // Removed overlay
                             .scaleEffect(isAppearing ? 1 : 0.8)
                             .opacity(isAppearing ? 1 : 0)
 
@@ -151,10 +139,7 @@ struct PotSheet: View {
 
                         // Confirm and cancel buttons
                         HStack {
-                            SheetButton(
-                                title: "Cancel",
-                                color: Color(uiColor: .systemGray4).opacity(0.3)
-                            ) {
+                            SheetButton(title: "Cancel") { // Changed: Removed explicit color
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                                     onClose()
                                 }
@@ -179,7 +164,7 @@ struct PotSheet: View {
                     VStack(spacing: 20) {
                         Text("Insufficient Funds")
                             .font(.title2.bold())
-                            .foregroundStyle(.white)
+                            .foregroundStyle(Color.primary) // Changed to .primary
                             .multilineTextAlignment(.center)
 
                         SheetButton(title: "OK") {
@@ -194,7 +179,7 @@ struct PotSheet: View {
             .padding(.vertical, 32)
             .padding(.horizontal)
         }
-        .presentationDetents([.height(500)])
+        .presentationDetents([.fraction(0.65)]) // Changed from .height(500)
         .onAppear {
             // Initialize slider value based on current pot and player balance
             let pot = Double(currentPot)
@@ -244,14 +229,14 @@ struct InsuranceSheet: View {
                 VStack(spacing: 16) {
                     Image(systemName: "shield.lefthalf.filled")
                         .font(.system(size: 48))
-                        .foregroundStyle(.blue)
-                        .shadow(color: .blue.opacity(0.3), radius: 8)
+                        .foregroundStyle(Color.accentColor) // Changed to .accentColor
+                        // Removed shadow: .shadow(color: .blue.opacity(0.3), radius: 8)
                         .scaleEffect(isAppearing ? 1 : 0.5)
                         .opacity(isAppearing ? 1 : 0)
 
                     Text("Insurance")
                         .font(.system(size: 32, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(Color.primary) // Changed to .primary
                         .opacity(isAppearing ? 1 : 0)
                         .offset(y: isAppearing ? 0 : 20)
                 }
@@ -261,16 +246,10 @@ struct InsuranceSheet: View {
                     VStack(spacing: 24) {
                         // Chip stack view displaying the current insurance bet amount
                         chipStack(amount: Int(insuranceSliderValue))
-                            .font(.system(size: 36, weight: .bold))
+                            .font(.system(size: 36, weight: .bold)) // Note: .font modifier on chipStack directly might not be standard.
                             .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .fill(Color(uiColor: .systemGray6).opacity(0.1))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 20)
-                                            .stroke(.white.opacity(0.1), lineWidth: 1)
-                                    )
-                            )
+                            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20)) // Changed background
+                            // Removed overlay
                             .scaleEffect(isAppearing ? 1 : 0.8)
                             .opacity(isAppearing ? 1 : 0)
 
@@ -294,10 +273,7 @@ struct InsuranceSheet: View {
 
                         // Confirm and skip buttons
                         HStack(spacing: 16) {
-                            SheetButton(
-                                title: "Skip",
-                                color: Color(uiColor: .systemGray4).opacity(0.3)
-                            ) {
+                            SheetButton(title: "Skip") { // Changed: Removed explicit color
                                 withAnimation {
                                     takeInsuranceAction(0)
                                     onClose()
@@ -320,7 +296,7 @@ struct InsuranceSheet: View {
                     VStack(spacing: 20) {
                         Text("Insufficient Balance for Insurance")
                             .font(.title3.bold())
-                            .foregroundStyle(.white)
+                            .foregroundStyle(Color.primary) // Changed to .primary
                             .multilineTextAlignment(.center)
 
                         SheetButton(title: "OK") {
@@ -336,7 +312,7 @@ struct InsuranceSheet: View {
             .padding(.vertical, 32)
             .padding(.horizontal)
         }
-        .presentationDetents([.height(500)])
+        .presentationDetents([.fraction(0.65)]) // Changed from .height(500)
         .onAppear {
             // Initialize insurance slider value
             insuranceSliderValue = 0

--- a/Blackjack/Views/GameView/SubViews.swift
+++ b/Blackjack/Views/GameView/SubViews.swift
@@ -12,17 +12,17 @@ import SwiftUI
 /// A customizable button view designed for use in sheets.
 struct SheetButton: View {
     let title: String
-    let color: Color
+    let color: Color? // Changed to optional
     let disabled: Bool
     let action: () -> Void
 
     /// Initializes a new `SheetButton`.
     /// - Parameters:
     ///   - title: The title text of the button.
-    ///   - color: The background color of the button. Defaults to black.
+    ///   - color: The background color of the button. Defaults to nil, which uses accentColor.
     ///   - disabled: A Boolean indicating if the button is disabled. Defaults to false.
     ///   - action: The action to perform when the button is tapped.
-    init(title: String, color: Color = .black, disabled: Bool = false, action: @escaping () -> Void) {
+    init(title: String, color: Color? = nil, disabled: Bool = false, action: @escaping () -> Void) { // Default color is nil
         self.title = title
         self.color = color
         self.disabled = disabled
@@ -33,20 +33,35 @@ struct SheetButton: View {
         Button(action: action) {
             Text(title)
                 .font(.headline)
-                .foregroundStyle(.white)
+                // Adaptive foregroundStyle
+                .foregroundStyle(disabled ? Color.gray : (color == nil ? Color.accentColor : (isLightColor(color ?? .black) ? .black : .white)))
                 .frame(maxWidth: .infinity)
-                .frame(height: 50)
+                // Removed fixed height, added padding
+                .padding(.vertical, 12)
+                .padding(.horizontal, 20)
                 .background(
-                    color
-                        .opacity(disabled ? 0.5 : 1) // Reduce opacity when disabled
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(.white.opacity(0.3), lineWidth: 1)
-                        )
+                    // Use material if color is nil, otherwise use the color
+                    Group {
+                        if let bgColor = color {
+                            bgColor.opacity(disabled ? 0.5 : 1)
+                        } else {
+                            .regularMaterial
+                        }
+                    }
                 )
-                .cornerRadius(16)
+                // Updated corner radius
+                .cornerRadius(12)
+                // Removed overlay
         }
         .disabled(disabled)
+    }
+
+    // Helper function to determine if a color is light
+    private func isLightColor(_ color: Color) -> Bool {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
+        let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return luminance > 0.5 // Threshold can be adjusted
     }
 }
 
@@ -55,13 +70,13 @@ struct SheetButton: View {
 /// A view representing a stack of chips with a specified amount.
 func chipStack(amount: Int) -> some View {
     HStack(spacing: 4) {
-        Image(systemName: "circle.fill")
+        Image(systemName: "dollarsign.circle.fill") // Changed icon
             .font(.system(size: 20))
-            .foregroundStyle(.orange)
+            .foregroundStyle(Color.accentColor) // Changed foreground style
         Text("$\(amount)")
             .font(.system(size: 18))
             .fontWeight(.bold)
-            .foregroundStyle(.white)
+            .foregroundStyle(Color.primary) // Changed foreground style
     }
 }
 
@@ -111,11 +126,11 @@ struct quickBetButton: View {
             Text(title)
                 .font(.subheadline)
                 .fontWeight(.medium)
-                .foregroundStyle(.white)
+                .foregroundStyle(Color.accentColor) // Changed foregroundStyle
                 .frame(maxWidth: .infinity)
-                .frame(height: 36)
-                .background(.black.opacity(0.6))
-                .clipShape(Capsule())
+                .padding(.vertical, 8) // Added padding, removed fixed height
+                .background(.thinMaterial, in: Capsule()) // Changed background
+                // .clipShape(Capsule()) // Already applied by background material shape
         }
     }
 }


### PR DESCRIPTION
This commit introduces several UI enhancements to LostSheet, PotSheet, and InsuranceSheet, along with their shared components (SheetButton, chipStack, quickBetButton), to align them more closely with native SwiftUI design principles and Apple's Human Interface Guidelines.

Key changes include:

- Replaced custom backgrounds with SwiftUI materials (.thinMaterial, .regularMaterial) for a modern, adaptive look.
- Standardized text colors to use adaptive system colors (Color.primary, Color.secondary, Color.accentColor) for automatic Light/Dark mode support.
- Removed custom shadows in favor of material depth or cleaner aesthetics.
- Updated SheetButton to use materials, adaptive colors, and dynamic sizing (padding instead of fixed height).
- Refreshed chipStack view with an updated icon (dollarsign.circle.fill) using Color.accentColor and adaptive text.
- Modernized quickBetButton with material background, accent color text, and dynamic sizing.
- Changed fixed sheet presentation detents (.height(500)) to a fractional detent (.fraction(0.65)) for better responsiveness across device sizes and improved Dynamic Type scalability.
- Ensured UI elements are consistently styled across all three sheets.

These changes result in a cleaner, more consistent, and more accessible user interface for the game's sheet presentations.