### PR TITLE
Refactor bottom UI and improve notifications

### DIFF
--- a/Blackjack/Views/GameView/ActionButton.swift
+++ b/Blackjack/Views/GameView/ActionButton.swift
@@ -21,7 +21,7 @@ struct ActionButton: View {
         label: String? = nil,
         isDisabled: Bool = false,
         circular: Bool = false,
-        cornerRadius: CGFloat = 64, // Default corner radius for non-circular buttons
+        cornerRadius: CGFloat = 10, // Default corner radius for non-circular buttons
         action: @escaping () -> Void
     ) {
         self.systemImage = systemImage

--- a/Blackjack/Views/GameView/BottomControlsContainerView.swift
+++ b/Blackjack/Views/GameView/BottomControlsContainerView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+// TopRoundedRectangle shape definition remains the same...
+struct TopRoundedRectangle: Shape {
+    var radius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+        path.addArc(center: CGPoint(x: rect.minX + radius, y: rect.minY + radius), radius: radius, startAngle: Angle(degrees: 180), endAngle: Angle(degrees: 270), clockwise: false)
+        path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.minY))
+        path.addArc(center: CGPoint(x: rect.maxX - radius, y: rect.minY + radius), radius: radius, startAngle: Angle(degrees: 270), endAngle: Angle(degrees: 0), clockwise: false)
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct BottomControlsContainerView<NotificationContent: View, MainContent: View>: View {
+    let notificationContent: NotificationContent
+    let mainContent: MainContent
+    var mainBackgroundColor: Color = Color.gray.opacity(0.2)
+    var notificationBackgroundColor: Color = Color.blue.opacity(0.3) // Contrasting color
+    var cornerRadius: CGFloat = 20
+
+    init(
+        mainBackgroundColor: Color = Color.gray.opacity(0.2),
+        notificationBackgroundColor: Color = Color.blue.opacity(0.3),
+        cornerRadius: CGFloat = 20,
+        @ViewBuilder notificationContent: () -> NotificationContent,
+        @ViewBuilder mainContent: () -> MainContent
+    ) {
+        self.mainBackgroundColor = mainBackgroundColor
+        self.notificationBackgroundColor = notificationBackgroundColor
+        self.cornerRadius = cornerRadius
+        self.notificationContent = notificationContent()
+        self.mainContent = mainContent()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            notificationContent
+                .padding(.horizontal, 8) // Add some horizontal padding for the notification content
+                .padding(.vertical, 4)   // Add some vertical padding
+                .background(notificationBackgroundColor) // Apply the contrasting background to the notification area
+                // This notification area will implicitly be at the top due to VStack ordering.
+
+            mainContent
+                // Add padding for mainContent if needed, e.g., .padding(.top, 8) if spacing is desired
+        }
+        // The .padding(.top, cornerRadius / 2) might need adjustment or be removed
+        // if the notification area itself provides enough visual spacing from the top curve.
+        // Let's remove it for now and see the effect.
+        // .padding(.top, cornerRadius / 2) 
+        .background(
+            TopRoundedRectangle(radius: cornerRadius)
+                .fill(mainBackgroundColor) // Main background for the whole container
+        )
+    }
+}

--- a/Blackjack/Views/NotificationView.swift
+++ b/Blackjack/Views/NotificationView.swift
@@ -22,7 +22,7 @@ struct NotificationView: View {
                 .background(
                     // Set background color based on whether the notification is active
                     notification.isActive ? Color.white : Color.accentColor,
-                    in: RoundedRectangle(cornerRadius: 12)
+                    in: RoundedRectangle(cornerRadius: 8)
                 )
                 // Define the transition animation for when the notification appears and disappears
                 .transition(

--- a/Blackjack/Views/RulesView.swift
+++ b/Blackjack/Views/RulesView.swift
@@ -101,6 +101,7 @@ struct RulesContentView: View {
 /// The main view displaying the rules of Blackjack.
 @MainActor
 struct RulesView: View {
+    @Environment(\.dismiss) private var dismiss // Added dismiss environment variable
     @State private var expandedSections: Set<UUID> = []
     @Environment(\.colorScheme) private var colorScheme
 
@@ -223,7 +224,12 @@ struct RulesView: View {
             .navigationBarTitleDisplayMode(.inline)
             .background(Color(.systemGroupedBackground))
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) { // New Done button
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) { // Existing toggle button
                     Button(action: toggleAllSections) {
                         Image(systemName: expandedSections.isEmpty ? "chevron.down.circle" : "chevron.up.circle")
                             .symbolRenderingMode(.multicolor)


### PR DESCRIPTION
This commit introduces a significant redesign of the bottom game controls UI:
- Replaced rounded buttons with squared-off versions.
- Implemented a new top-rounded container for the entire bottom section (balance, bet, controls, notifications) with a distinct background.
- Stabilized the "Current Bet" and "Change Bet" sections so they do not move during button transitions by using a fixed height for the actions area and opacity transitions.
- Simplified button animations by primarily relying on opacity changes.
- Redesigned notification presentation:
    - Notifications are now integrated into the new bottom container.
    - A contrasting background strip at the top of the container is dedicated to notifications.
    - Ensured notifications do not overlap or move other components.
- Fixed RulesView: The toolbar button (now a "Done" button) correctly dismisses the sheet.