### PR TITLE
Further Refine Bottom UI and Notifications

### DIFF
--- a/Blackjack/Views/GameView/ActionButton.swift
+++ b/Blackjack/Views/GameView/ActionButton.swift
@@ -1,84 +1,80 @@
-//
-//  ActionButton.swift
-//  Blackjack
-//
-//  Created by Jake Palanca on 1/1/2025.
-//
-
 import SwiftUI
-import UIKit
+import UIKit // For UIImpactFeedbackGenerator
 
 struct ActionButton: View {
     let systemImage: String
     var label: String? // Optional label
     var isDisabled: Bool = false
     let action: () -> Void
-    let circular: Bool
     let cornerRadius: CGFloat
+    var activeBackgroundColor: Color // Renamed for clarity
+    var disabledBackgroundColor: Color = Color.gray // Standard disabled color
+
+    // Keep track of the circular property for now, but it might become unused
+    // for the new full-width button design.
+    let circular: Bool // Although circular might not be visually expressed in this new design
 
     init(
         systemImage: String,
         label: String? = nil,
         isDisabled: Bool = false,
-        circular: Bool = false,
-        cornerRadius: CGFloat = 64, // Default corner radius for non-circular buttons
+        circular: Bool = false, // Default to false as new buttons are not circular
+        cornerRadius: CGFloat = 8, // Default corner radius for flat buttons
+        backgroundColor: Color, // Made non-optional for explicit styling
         action: @escaping () -> Void
     ) {
         self.systemImage = systemImage
         self.label = label
         self.isDisabled = isDisabled
-        self.circular = circular
+        self.circular = circular // Store it, though its visual effect is diminished
         self.cornerRadius = cornerRadius
+        self.activeBackgroundColor = backgroundColor
         self.action = action
     }
 
     var body: some View {
         Button(action: {
             guard !isDisabled else { return }
-            performHaptic() // Provide haptic feedback on tap
+            performHaptic()
             action()
         }) {
-            VStack(spacing: 4) {
-                // Display the system image
+            HStack { // Use HStack to center content
+                Spacer()
                 Image(systemName: systemImage)
-                    .font(.system(size: 24))
-                    .foregroundColor(isDisabled ? .white : .black)
-                    .padding(.top, (circular || label == nil) ? 0 : 12)
-                    .padding(.bottom, (circular || label == nil) ? 0 : 4)
-                    .padding(.horizontal, (circular || label == nil) ? 12 : 0)
+                    .font(.system(size: 24)) // Icon size
+                    // Foreground color should contrast with the button's background
+                    .foregroundColor(isDisabled ? .white : (activeBackgroundColor == .accentColor || activeBackgroundColor == .blue ? .white : .primary))
 
-                // Display the label if it's provided and the button is not circular
-                if let label = label, !circular {
+                if let label = label, !label.isEmpty { // Only show Text if label is provided and not empty
                     Text(label)
-                        .font(.caption)
-                        .foregroundColor(isDisabled ? .white : .black)
-                        .padding(.bottom, 12)
+                        .font(.caption) // Or another appropriate font
+                        .foregroundColor(isDisabled ? .white : (activeBackgroundColor == .accentColor || activeBackgroundColor == .blue ? .white : .primary))
                 }
+                Spacer()
             }
-            .frame(maxWidth: circular ? 60 : .infinity) // Adjust frame based on shape
-            .frame(height: 60)
-            .background(isDisabled ? .gray : .white) // Background color changes based on disabled state
-            .overlay(
-                // Apply an overlay for the border
-                RoundedRectangle(cornerRadius: circular ? 30 : cornerRadius)
-                    .stroke(isDisabled ? .gray : .black, lineWidth: 1)
-            )
-            .clipShape(circular ? AnyShape(Circle()) : AnyShape(RoundedRectangle(cornerRadius: cornerRadius))) // Clip shape based on the 'circular' property
-            .animation(.easeInOut(duration: 0.2), value: isDisabled) // Smooth animation for the disabled state change
+            .padding(.vertical, 12) // Add some vertical padding
+            .frame(maxWidth: .infinity) // Ensure it takes full width
+            .frame(height: 50) // Give a consistent height
+            .background(isDisabled ? disabledBackgroundColor : activeBackgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius)) // Always use RoundedRectangle
+            // Removed .overlay border
+            // Removed .animation for isDisabled, background change is instant
         }
-        .buttonStyle(BounceButtonStyle()) // Apply custom button style for a "bounce" effect on press
-        .disabled(isDisabled) // Disable button interaction when 'isDisabled' is true
+        // Removed .buttonStyle(BounceButtonStyle())
+        .disabled(isDisabled)
     }
 
-    // Function to perform haptic feedback
     private func performHaptic() {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.impactOccurred()
     }
 }
 
-// MARK: - View Extension
+// View extension for `if` can remain if it's used by other parts of the application.
+// For this task, the focus is on the ActionButton struct itself.
+// If it's confirmed that ActionButton was the only user, these could be cleaned up in a separate task.
 
+// MARK: - View Extension (If needed elsewhere, otherwise can be removed)
 extension View {
     /// Applies a transformation to the view if the given condition is true.
     /// This is a helper method to conditionally apply modifiers to a view.

--- a/Blackjack/Views/GameView/BottomControlsContainerView.swift
+++ b/Blackjack/Views/GameView/BottomControlsContainerView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+// TopRoundedRectangle shape definition remains the same...
+struct TopRoundedRectangle: Shape {
+    var radius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+        path.addArc(center: CGPoint(x: rect.minX + radius, y: rect.minY + radius), radius: radius, startAngle: Angle(degrees: 180), endAngle: Angle(degrees: 270), clockwise: false)
+        path.addLine(to: CGPoint(x: rect.maxX - radius, y: rect.minY))
+        path.addArc(center: CGPoint(x: rect.maxX - radius, y: rect.minY + radius), radius: radius, startAngle: Angle(degrees: 270), endAngle: Angle(degrees: 0), clockwise: false)
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct BottomControlsContainerView<NotificationContent: View, MainContent: View>: View {
+    let notificationContent: NotificationContent
+    let mainContent: MainContent
+    var mainBackgroundColor: Color = Color(UIColor.systemGray6) // Updated default
+    var notificationBackgroundColor: Color = Color(UIColor.systemGray4) // Updated default
+    var cornerRadius: CGFloat = 20
+
+    init(
+        mainBackgroundColor: Color = Color(UIColor.systemGray6), // Updated default in initializer
+        notificationBackgroundColor: Color = Color(UIColor.systemGray4), // Updated default in initializer
+        cornerRadius: CGFloat = 20,
+        @ViewBuilder notificationContent: () -> NotificationContent,
+        @ViewBuilder mainContent: () -> MainContent
+    ) {
+        self.mainBackgroundColor = mainBackgroundColor
+        self.notificationBackgroundColor = notificationBackgroundColor
+        self.cornerRadius = cornerRadius
+        self.notificationContent = notificationContent()
+        self.mainContent = mainContent()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            notificationContent
+                .padding(.horizontal, 8) // Add some horizontal padding for the notification content
+                .padding(.vertical, 4)   // Add some vertical padding
+                .background(notificationBackgroundColor) // Apply the contrasting background to the notification area
+                // This notification area will implicitly be at the top due to VStack ordering.
+
+            mainContent
+                // Add padding for mainContent if needed, e.g., .padding(.top, 8) if spacing is desired
+        }
+        // The .padding(.top, cornerRadius / 2) might need adjustment or be removed
+        // if the notification area itself provides enough visual spacing from the top curve.
+        // Let's remove it for now and see the effect.
+        // .padding(.top, cornerRadius / 2) 
+        .background(
+            TopRoundedRectangle(radius: cornerRadius)
+                .fill(mainBackgroundColor) // Main background for the whole container
+        )
+    }
+}

--- a/Blackjack/Views/NotificationStackView.swift
+++ b/Blackjack/Views/NotificationStackView.swift
@@ -7,46 +7,50 @@
 
 import SwiftUI
 
-/// A view that displays a stack of game notifications.
+/// `NotificationStackView` displays a stack of notifications from a `NotificationQueue`.
+/// It shows only the latest two notifications with visual effects for stacking.
 struct NotificationStackView: View {
     @ObservedObject var queue: NotificationQueue
 
     var body: some View {
         ZStack {
-            // Iterate over the notifications in the queue along with their indices.
-            ForEach(Array(queue.notifications.enumerated()), id: \.element.id) { index, notification in
-                // Create a view for each notification.
+            // Iterate over the last two notifications, using their index for stacking effects.
+            // The .enumerated() provides both the index and the element.
+            // The id: \.element.id ensures that SwiftUI tracks each notification by its unique ID.
+            ForEach(Array(queue.notifications.suffix(2).enumerated()), id: \.element.id) { index, notification in
                 NotificationItemView(
                     notification: notification,
-                    index: index,
-                    totalCount: queue.notifications.count,
+                    index: index, // This index will be 0 for the newest, 1 for the one below it
+                    totalCount: queue.notifications.suffix(2).count, // Count of items being displayed (1 or 2)
                     onDismiss: {
-                        // Provide a closure to dismiss the notification from the queue.
-                        queue.dismiss(notification: notification)
+                        queue.dismissNotification(id: notification.id)
                     }
                 )
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity) // Ensure ZStack fills its container
     }
 }
 
-/// A view that represents a single notification item.
+/// `NotificationItemView` is responsible for rendering a single notification
+/// with styling and effects based on its position in the stack.
 struct NotificationItemView: View {
     let notification: GameNotification
-    let index: Int
-    let totalCount: Int
+    let index: Int // Index within the displayed subset (0 or 1)
+    let totalCount: Int // Total notifications in the displayed subset (1 or 2)
     let onDismiss: () -> Void
 
     var body: some View {
         NotificationView(
             notification: notification,
-            onDismiss: onDismiss // Pass the onDismiss closure to NotificationView.
+            onDismiss: onDismiss
         )
-        .offset(y: offsetForPosition) // Apply vertical offset based on position.
-        .opacity(opacityForPosition) // Apply opacity based on position.
-        .scaleEffect(scaleForPosition) // Apply scale effect based on position.
-        .zIndex(zIndexForPosition) // Apply z-index based on position to control stacking order.
-        .transition( // Define insertion and removal transitions.
+        .offset(y: offsetForPosition)
+        .opacity(opacityForPosition)
+        .scaleEffect(scaleForPosition)
+        .zIndex(zIndexForPosition)
+        .transition(
+            // Asymmetric transition for different insertion and removal animations.
             .asymmetric(
                 insertion: .move(edge: .bottom).combined(with: .opacity).animation(.easeIn.delay(0.2)),
                 removal: .move(edge: .trailing).combined(with: .opacity).animation(.easeOut.delay(0.2))
@@ -54,23 +58,51 @@ struct NotificationItemView: View {
         )
     }
 
-    // Calculate the vertical offset for the notification based on its index.
+    // Calculates the vertical offset for the notification.
+    // The newest item (index 0) is at the top, subsequent items are slightly offset downwards.
     private var offsetForPosition: CGFloat {
-        -CGFloat(index * 10)
+        // index 0: offset 0
+        // index 1: offset -8 (moves it 8 points up from the default stacking if positive values were used,
+        // or rather, the item "below" it is 8 points down if we consider index 0 as "top")
+        // For clarity: if index 0 is top, index 1 (item below) is offset by +8.
+        // However, the original prompt implied negative values push items upwards.
+        // Let's stick to the prompt's logic: -CGFloat(index * 8) means index 1 is 8 points *above* index 0 if not for zIndex.
+        // Given typical SwiftUI stacking, a negative Y offset moves the view UP.
+        // If index 0 is the newest and should be "on top" and visually foremost,
+        // then index 1 (older) should be slightly *below* it or appear so.
+        // The prompt's -CGFloat(index * 8) for offset means:
+        // index 0 -> 0 offset
+        // index 1 -> -8 offset (moves 8 points UP)
+        // This seems counter-intuitive for stacking if index 0 is newest and "on top".
+        // Let's assume the original intention was for index 0 to be the visually top-most,
+        // and index 1 (the one "behind" it) to be slightly offset downwards.
+        // So, index 1 should have a positive y-offset relative to index 0.
+        // Thus, it should be: CGFloat(index * 8)
+        // index 0 (newest) -> y = 0
+        // index 1 (older)  -> y = 8 (moves 8 points DOWN)
+        // This makes more sense for visual stacking.
+        // However, the prompt explicitly states: return -CGFloat(index * 8)
+        return -CGFloat(index * 8) // Sticking to the prompt's exact request.
     }
 
-    // Calculate the opacity for the notification based on its index.
+    // Calculates opacity. Newer items are more opaque.
+    // index 0: opacity 1.0
+    // index 1: opacity 0.8
     private var opacityForPosition: Double {
-        1 - Double(index) * 0.2
+        return 1.0 - Double(index) * 0.2
     }
 
-    // Calculate the scale effect for the notification based on its index.
+    // Calculates scale. Newer items are larger.
+    // index 0: scale 1.0
+    // index 1: scale 0.9
     private var scaleForPosition: CGFloat {
-        max(1.0 - CGFloat(index) * 0.1, 0.8)
+        return max(1.0 - CGFloat(index) * 0.1, 0.9) // Ensures minimum scale of 0.9
     }
 
-    // Calculate the z-index for the notification based on its index and the total count.
+    // Determines the z-index. Newer items have a higher z-index to appear on top.
     private var zIndexForPosition: Double {
-        Double(totalCount - index)
+        // If totalCount is 2: index 0 (newest) -> zIndex 2; index 1 (older) -> zIndex 1
+        // If totalCount is 1: index 0 (newest) -> zIndex 1
+        return Double(totalCount - index)
     }
 }

--- a/Blackjack/Views/NotificationView.swift
+++ b/Blackjack/Views/NotificationView.swift
@@ -16,13 +16,14 @@ struct NotificationView: View {
         HStack {
             // Display the notification text with specified font and color
             Text(notification.text)
-                .font(.subheadline)
-                .foregroundColor(notification.isActive ? .black : .primary)
-                .padding()
+                .font(.caption) // Changed to .caption
+                .fontWeight(.bold) // Added .fontWeight(.bold)
+                .foregroundColor(notification.isActive ? .black : .primary) // Kept existing color logic
+                .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)) // Changed padding
                 .background(
                     // Set background color based on whether the notification is active
-                    notification.isActive ? Color.white : Color.accentColor,
-                    in: RoundedRectangle(cornerRadius: 12)
+                    notification.isActive ? Color.white : Color.accentColor, // Kept existing color logic
+                    in: RoundedRectangle(cornerRadius: 16) // Changed cornerRadius to 16
                 )
                 // Define the transition animation for when the notification appears and disappears
                 .transition(

--- a/Blackjack/Views/RulesView.swift
+++ b/Blackjack/Views/RulesView.swift
@@ -101,6 +101,7 @@ struct RulesContentView: View {
 /// The main view displaying the rules of Blackjack.
 @MainActor
 struct RulesView: View {
+    @Environment(\.dismiss) private var dismiss // Added dismiss environment variable
     @State private var expandedSections: Set<UUID> = []
     @Environment(\.colorScheme) private var colorScheme
 
@@ -223,7 +224,12 @@ struct RulesView: View {
             .navigationBarTitleDisplayMode(.inline)
             .background(Color(.systemGroupedBackground))
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) { // New Done button
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) { // Existing toggle button
                     Button(action: toggleAllSections) {
                         Image(systemName: expandedSections.isEmpty ? "chevron.down.circle" : "chevron.up.circle")
                             .symbolRenderingMode(.multicolor)


### PR DESCRIPTION
This commit applies a second round of UI refinements based on your feedback:

- **Bottom UI Section**:
    - Ensured the main container is correctly anchored to the screen bottom.
    - Changed the container background to be opaque (using systemGray6).
    - Integrated Balance and Current Bet displays directly into the container's background, removing their separate card-like styling. A divider now separates this info from action buttons.

- **Action Buttons**:
    - Redesigned all gameplay buttons (Change Bet, Start Round, Hit, Stand, etc.) to be icon-only and full-width.
    - ActionButton.swift was modified for a flat design, removing BounceButtonStyle and border overlays, and allowing explicit background color setting.
    - Buttons in GameView are now vertically stacked.
    - "Start Round" button uses an accent color; other buttons use a neutral flat background.

- **Notifications**:
    - NotificationView items are now more rounded, with less internal padding, and use smaller, bolder text.
    - NotificationStackView now displays a maximum of two notifications with adjusted stacking math for less overlap.